### PR TITLE
This PR provides a simple wrapper to provide correct ESM export

### DIFF
--- a/lib-esm/index.mjs
+++ b/lib-esm/index.mjs
@@ -1,0 +1,3 @@
+import FiveServer from '../lib/index.js'
+
+export default FiveServer.default

--- a/package.json
+++ b/package.json
@@ -3,11 +3,19 @@
   "version": "0.0.24",
   "description": "Development Server with Live Reload Capability. (Maintained Fork of Live Server)",
   "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "module": "lib-esm/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./lib-esm/index.mjs",
+      "require": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "live-server": "./lib/bin.js",
     "five-server": "./lib/bin.js"
   },
+  "types": "lib/index.d.ts",
   "keywords": [
     "browser",
     "development",


### PR DESCRIPTION
So, given the complexity of `five-server` and that there really is only one export the best solution I could come up with is providing an index.mjs wrapper which simply provides a correct ESM default export from the CJS code. 

I added the proper entries into package.json as well. It certainly will work Node 12.6+ when the exports field was introduced for package.json. It should work prior as well w/ "module" added for below Node 12.6 though a test or two couldn't hurt to check. 