### PR TITLE
Added setTimeout around popup when connection closes

### DIFF
--- a/client/injected.ts
+++ b/client/injected.ts
@@ -315,7 +315,9 @@ if ('WebSocket' in window) {
         document.head.appendChild(style)
       }
       socket.onclose = function (e) {
-        popup('lost connection to dev server', 'error')
+        setTimeout(function () {
+          popup('lost connection to dev server', 'error')
+        }, 300)
         if (attempts === 0) console.log('Socket is closed. Reconnect will be attempted in 1 second.', e.reason)
 
         setTimeout(function () {


### PR DESCRIPTION
When a page is reloaded, the socket will be closed. If
you are editing and reloading HTML files, it could be
that you are frequently reloading the pages. In this
context, it is _not_ an error for the page to be reloaded,
so it is confusing if a red error message pops up on
the page.

This fix adds a `setTimeout` around the popup function
which will prevent the popup from closing when the page
is reloaded.

Closes #16