### PR TITLE
Per-page reload opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ module.exports = {
 }
 ```
 
+To prevent a single page from automatically reloading, add `data-server-no-reload` to the `<body>` tag:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+    ...
+</head>
+<body data-server-no-reload>
+  ...
+</body>
+</html>
+```
+
+This will omit the usually injected Javascript from being instantiated on that given page.
+
 ### Browser of your choice
 
 The option browser can be a `string` or an `string[]`.  

--- a/client/injected.ts
+++ b/client/injected.ts
@@ -7,7 +7,12 @@ import { appendPathToUrl } from '../src/helpers'
 // manipulates it inside window.addEventListener('load', (...))
 let _internalDOMBody
 
-if ('WebSocket' in window) {
+const block = document.body.hasAttribute('data-server-no-reload');
+
+if (block) {
+  console.info('[Five Server] Reload disabled due to \'data-server-no-reload\' attribute on BODY element')
+}
+if ('WebSocket' in window && !block) {
   window.addEventListener('load', () => {
     console.log('[Five Server] connecting...')
 


### PR DESCRIPTION
TLDR; If the attribute `data-server-no-reload` is found on the BODY tag, the client-side injection is omitted.

At the moment, all browser windows are reloaded when there is a source change, regardless of whether the source change affects them. This is a robust, base logic.

However, there are instances where one wants to prevent a page from being reloaded by changes. Eg, if `a.html` opens up a connection to a web socket server or media device, it's annoying if a change in `b.html` causes `a.html` to be unnecessarily reloaded.

This addition changes the injection script to check for the presence of an attribute on the `BODY` element. If it's there, the injection is skipped, and the page will have to be manually reloaded. An info message is printed to the console as a FYI.