### PR TITLE
Check if document.body exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ module.exports = {
 }
 ```
 
+To prevent a single page from automatically reloading, add `data-server-no-reload` to the `<body>` tag:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+    ...
+</head>
+<body data-server-no-reload>
+  ...
+</body>
+</html>
+```
+
+This will omit the usually injected Javascript from being instantiated on that given page.
+
 ### Browser of your choice
 
 The option browser can be a `string` or an `string[]`.  

--- a/client/injected.ts
+++ b/client/injected.ts
@@ -7,7 +7,12 @@ import { appendPathToUrl } from '../src/helpers'
 // manipulates it inside window.addEventListener('load', (...))
 let _internalDOMBody
 
-if ('WebSocket' in window) {
+const block = document.body.hasAttribute('data-server-no-reload');
+
+if (block) {
+  console.info('[Five Server] Reload disabled due to \'data-server-no-reload\' attribute on BODY element')
+}
+if ('WebSocket' in window && !block) {
   window.addEventListener('load', () => {
     console.log('[Five Server] connecting...')
 

--- a/client/injected.ts
+++ b/client/injected.ts
@@ -7,7 +7,7 @@ import { appendPathToUrl } from '../src/helpers'
 // manipulates it inside window.addEventListener('load', (...))
 let _internalDOMBody
 
-const block = document.body.hasAttribute('data-server-no-reload');
+const block = (document.body) ? document.body.hasAttribute('data-server-no-reload') : false;
 
 if (block) {
   console.info('[Five Server] Reload disabled due to \'data-server-no-reload\' attribute on BODY element')


### PR DESCRIPTION
There are times when `document.body` doesn't exist when the Five Server default file-listing page is shown. This checks for that to avoid a warning.

(sorry for missing this in my first patch)