### PR TITLE
Add support to set a base URL to allow proxying

### DIFF
--- a/client/injected.ts
+++ b/client/injected.ts
@@ -17,9 +17,10 @@ if ('WebSocket' in window && !block) {
     console.log('[Five Server] connecting...')
 
     const script = document.querySelector('[data-id="five-server"]') as HTMLScriptElement
-
+    
+    const baseurl = new URL(script.src).pathname.split("/").slice(0,-1).join("/")
     const protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://'
-    const address = appendPathToUrl(`${protocol}${new URL(script.src).host}`, 'fsws')
+    const address = appendPathToUrl(`${protocol}${new URL(script.src).host}${baseurl}`, 'fsws')
 
     // check if we need to clone the body for the "injectBody" feature or not
     const optionsInjectBody = script.getAttribute('data-inject-body')
@@ -190,7 +191,8 @@ if ('WebSocket' in window && !block) {
     const addDiffDOM = (): Promise<void> => {
       _diffDOMStatus = 'loading'
       return new Promise(resolve => {
-        const url = `//${new URL(script.src).host}/fiveserver/scripts/diffDOM.js`
+        const baseurl = new URL(script.src).pathname.split("/").slice(0,-1).join("/")
+        const url = `//${new URL(script.src).host}${baseurl}/fiveserver/scripts/diffDOM.js`
         const s = document.createElement('script')
         s.type = 'text/javascript'
         s.src = url
@@ -409,8 +411,9 @@ if ('WebSocket' in window && !block) {
       statusChecks++
       const p = new URL(script.src).protocol
       const h = new URL(script.src).host
+      const baseurl = new URL(script.src).pathname.split("/").slice(0,-1).join("/")
 
-      const url = `${p}//${h}/fiveserver/status`
+      const url = `${p}//${h}${baseurl}/fiveserver/status`
 
       try {
         const res = await fetch(url)

--- a/public/serve-explorer/explorer.html
+++ b/public/serve-explorer/explorer.html
@@ -60,7 +60,7 @@
 
     <div id="wrapper">
       <div class="directory">
-        <h1><a href="/">~</a>{linked-path}</h1>
+        <h1><a href="{server-root}">~</a>{linked-path}</h1>
         {files}
       </div>
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -33,6 +33,10 @@ for (let i = process.argv.length - 1; i >= 2; --i) {
     const root = arg.substring(7)
     opts.root = root
     process.argv.splice(i, 1)
+  } else if (arg.indexOf('--serverRoot=') > -1) {
+    const serverRoot = arg.substring(13)
+    opts.serverRoot = serverRoot
+    process.argv.splice(i, 1)
   } else if (arg.indexOf('--useLocalIp') > -1) {
     opts.useLocalIp = true
     process.argv.splice(i, 1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,7 @@ export default class LiveServer {
 
     // inject to any (converts and file to a .html file (if possible))
     // (makes that nice preview page)
-    app.use(preview(root, this.servePreview))
+    app.use(preview(root, serverRoot, this.servePreview))
 
     // explorer middleware (previously serve-index)
     app.use(explorer(root, { icons: true, hidden: false, dotFiles: true, serverRoot: serverRoot}))
@@ -412,7 +412,7 @@ export default class LiveServer {
     app.use(favicon)
 
     // serve 403/404 page
-    app.use(notFound(root))
+    app.use(notFound(root, serverRoot))
 
     // create http server
     if (_https !== null && _https !== false) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,7 @@ export default class LiveServer {
       port = 5500,
       proxy = {},
       remoteLogs = false,
+      serverRoot = "",
       useLocalIp = false,
       wait = 100,
       withExtension = 'unset',
@@ -350,7 +351,7 @@ export default class LiveServer {
       if (R.indexOf('/') !== 0) R = `/${R}`
 
       // inject code to html and php files
-      app.use(R, injectCode(mountPath, PHP, injectBody || false))
+      app.use(R, injectCode(mountPath, serverRoot, PHP, injectBody || false))
 
       // serve static files via express.static()
       app.use(R, serveStatic(mountPath))
@@ -382,14 +383,14 @@ export default class LiveServer {
       }
 
       const { proxyMiddleware } = require('./middleware/proxy')
-      app.use(ROUTE, proxyMiddleware(proxyOpts, injectBody || false))
+      app.use(ROUTE, proxyMiddleware(proxyOpts, serverRoot, injectBody || false))
       if (this.logLevel >= 1) message.log(`Mapping "${ROUTE}" to "${TARGET}"`)
     }
 
     // find index file and modify req.url
     app.use(findIndex(root, withExtension, ['html', 'php']))
 
-    const injectHandler = injectCode(root, PHP, injectBody || false)
+    const injectHandler = injectCode(root, serverRoot, PHP, injectBody || false)
 
     // inject five-server script
     app.use(injectHandler)
@@ -405,7 +406,7 @@ export default class LiveServer {
     app.use(preview(root, this.servePreview))
 
     // explorer middleware (previously serve-index)
-    app.use(explorer(root, { icons: true, hidden: false, dotFiles: true }))
+    app.use(explorer(root, { icons: true, hidden: false, dotFiles: true, serverRoot: serverRoot}))
 
     // no one want to see a 404 favicon error
     app.use(favicon)

--- a/src/middleware/explorer.ts
+++ b/src/middleware/explorer.ts
@@ -324,7 +324,8 @@ function createHtmlRender(template) {
           createHtmlFileList(locals.fileList, locals.serverRoot + locals.directory, locals.displayIcons, locals.viewName)
         )
         .replace(/\{directory\}/g, escapeHtml(locals.directory))
-        .replace(/\{linked-path\}/g, htmlPath(locals.directory))
+        .replace(/\{linked-path\}/g, htmlPath(locals.directory, locals.serverRoot))
+        .replace(/\{server-root\}/g, escapeHtml(locals.serverRoot))
 
       callback(null, body)
     })
@@ -351,7 +352,7 @@ function getRequestedDir(req) {
   }
 }
 
-export function htmlPath(dir) {
+export function htmlPath(dir, webdir) {
   const parts = dir.split('/')
   const crumb = new Array(parts.length)
 
@@ -360,7 +361,7 @@ export function htmlPath(dir) {
 
     if (part) {
       parts[i] = encodeURIComponent(part)
-      crumb[i] = '<a href="' + escapeHtml(parts.slice(0, i + 1).join('/')) + '">' + escapeHtml(part) + '</a>'
+      crumb[i] = '<a href="' + escapeHtml(webdir + parts.slice(0, i + 1).join('/')) + '">' + escapeHtml(part) + '</a>'
     }
   }
 

--- a/src/middleware/explorer.ts
+++ b/src/middleware/explorer.ts
@@ -71,6 +71,7 @@ const explorer = (root, options?: any) => {
 
   // resolve root to absolute and normalize
   const rootPath = normalize(resolve(root) + sep)
+  const serverRoot = opts.serverRoot
 
   const filter = opts.filter
   const hidden = opts.hidden || false
@@ -140,14 +141,14 @@ const explorer = (root, options?: any) => {
           })
         files.sort()
 
-        explorer['html'](req, res, files, next, originalDir, showUp, icons, path, view, template, stylesheet)
+        explorer['html'](req, res, files, next, originalDir, serverRoot, showUp, icons, path, view, template, stylesheet)
       })
     })
   }
 }
 export default explorer
 
-explorer.html = function _html(req, res, files, next, dir, showUp, icons, path, view, template, stylesheet) {
+explorer.html = function _html(req, res, files, next, dir, serverRoot, showUp, icons, path, view, template, stylesheet) {
   const render = typeof template !== 'function' ? createHtmlRender(template) : template
 
   if (showUp) {
@@ -168,6 +169,7 @@ explorer.html = function _html(req, res, files, next, dir, showUp, icons, path, 
       // create locals for rendering
       const locals = {
         directory: dir,
+        serverRoot: serverRoot,
         displayIcons: Boolean(icons),
         fileList: fileList,
         path: path,
@@ -223,7 +225,7 @@ explorer.plain = function _plain(req, res, files, next, dir, showUp, icons, path
   })
 }
 
-function createHtmlFileList(files, dir, useIcons, view) {
+function createHtmlFileList(files, webroot, useIcons, view) {
   let html =
     '<ul id="files" class="view-' +
     escapeHtml(view) +
@@ -240,7 +242,7 @@ function createHtmlFileList(files, dir, useIcons, view) {
     .map(function (file) {
       const classes: string[] = []
       const isDir = file.stat && file.stat.isDirectory()
-      const path = dir.split('/').map(function (c) {
+      const path = webroot.split('/').map(function (c) {
         return encodeURIComponent(c)
       })
 
@@ -319,7 +321,7 @@ function createHtmlRender(template) {
         .replace(/\{style\}/g, locals.style.concat(iconStyle(locals.fileList, locals.displayIcons)))
         .replace(
           /\{files\}/g,
-          createHtmlFileList(locals.fileList, locals.directory, locals.displayIcons, locals.viewName)
+          createHtmlFileList(locals.fileList, locals.serverRoot + locals.directory, locals.displayIcons, locals.viewName)
         )
         .replace(/\{directory\}/g, escapeHtml(locals.directory))
         .replace(/\{linked-path\}/g, htmlPath(locals.directory))

--- a/src/middleware/injectCode.ts
+++ b/src/middleware/injectCode.ts
@@ -75,15 +75,15 @@ export class Inject extends Writable {
   }
 }
 
-export const code = (filePath: string, injectBodyOptions: boolean) => {
+export const code = (filePath: string, serverRoot: string, injectBodyOptions: boolean) => {
   const a = injectBodyOptions ? ' data-inject-body="true"' : ''
   return `<!-- Code injected by Five-server -->
-  <script async data-id="five-server" data-file="${filePath}"${a} type="application/javascript" src="/fiveserver.js"></script>
+  <script async data-id="five-server" data-file="${filePath}"${a} type="application/javascript" src="${serverRoot}/fiveserver.js"></script>
   `
 }
 
 /** Injects the five-server script into the html page and converts the cache attributes. */
-export const injectCode = (root: string, PHP: any, injectBodyOptions: boolean) => {
+export const injectCode = (root: string, serverRoot: string, PHP: any, injectBodyOptions: boolean) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const { pathname } = url.parse(req.url)
 
@@ -100,7 +100,7 @@ export const injectCode = (root: string, PHP: any, injectBodyOptions: boolean) =
       if (!existsSync(filePath)) return next()
       if (!statSync(filePath).isFile()) return next()
 
-      const inject = new Inject(['</head>', '</html>', '</body>'], code(filePath, injectBodyOptions))
+      const inject = new Inject(['</head>', '</html>', '</body>'], code(filePath, serverRoot, injectBodyOptions))
 
       if (extname(pathname) === '.php') {
         const html = await PHP.parseFile(filePath, res)

--- a/src/middleware/notFound.ts
+++ b/src/middleware/notFound.ts
@@ -9,21 +9,21 @@ import { STATUS_CODE } from '../public'
 import { fileDoesExist } from '../misc'
 import { htmlPath } from './explorer'
 
-export const notFound = (root: string) => {
+export const notFound = (root: string, serverRoot: string) => {
   return async (req: any, res: any, next: any) => {
     // join / normalize from root dir
     const path = normalize(join(root, req.url))
     const file = req.url.replace(/^\//gm, '') // could be c:/Users/USERNAME/Desktop/website/ for example
 
     if (await fileDoesExist(file)) {
-      const html = STATUS_CODE.replace('{linked-path}', htmlPath(decodeURI(req.url)))
+      const html = STATUS_CODE.replace('{linked-path}', htmlPath(decodeURI(req.url), serverRoot))
         .replace('{status}', '403')
         .replace('{message}', `Can't access files outside of root.`)
       return res.status(403).send(html)
     }
 
     if (!(await fileDoesExist(path))) {
-      const html = STATUS_CODE.replace('{linked-path}', htmlPath(decodeURI(req.url)))
+      const html = STATUS_CODE.replace('{linked-path}', htmlPath(decodeURI(req.url), serverRoot))
         .replace('{status}', '404')
         .replace('{message}', 'This page could not be found.')
       return res.status(404).send(html)

--- a/src/middleware/preview.ts
+++ b/src/middleware/preview.ts
@@ -10,7 +10,7 @@ import { readFileSync, statSync } from 'fs'
 import { fileTypes } from '../fileTypes'
 import { htmlPath } from './explorer'
 
-export const preview = (root: string, injectToAny: boolean) => {
+export const preview = (root: string, serverRoot: string, injectToAny: boolean) => {
   return (req, res, next) => {
     if (!injectToAny) return next()
     if (!['.preview', '.fullscreen', '.php'].includes(extname(req.url))) return next()
@@ -101,7 +101,7 @@ export const preview = (root: string, injectToAny: boolean) => {
 
       const TEMPLATE = isFullscreenPreview ? PREVIEW_FULLSCREEN : PREVIEW
 
-      const html = TEMPLATE.replace('{linked-path}', htmlPath(URL))
+      const html = TEMPLATE.replace('{linked-path}', htmlPath(URL, serverRoot))
         .replace(/{fileName}/gm, fileName)
         .replace(/{ext}/gm, ext)
         .replace('{phpMsg}', phpMsg ? `<div class="message"><p>${phpMsg}</p></div>` : '')

--- a/src/middleware/proxy.ts
+++ b/src/middleware/proxy.ts
@@ -35,7 +35,7 @@ interface RequestWithRetry extends Request {
   retries: number
 }
 
-export const proxyMiddleware = (options: ProxyMiddlewareOptions, injectBody: boolean) => {
+export const proxyMiddleware = (options: ProxyMiddlewareOptions, serverRoot: string, injectBody: boolean) => {
   // enable ability to quickly pass a url for shorthand setup
   if (typeof options === 'string') {
     options = require('url').parse(options)
@@ -117,7 +117,7 @@ export const proxyMiddleware = (options: ProxyMiddlewareOptions, injectBody: boo
 
       // inject the reload script before proxying
       if (shouldInject) {
-        const inject = new Inject(['</head>', '</html>', '</body>'], code(url, injectBody))
+        const inject = new Inject(['</head>', '</html>', '</body>'], code(url, serverRoot, injectBody))
 
         request.pipe(inject).on('finish', () => {
           // could not inject the script :/

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,8 @@ export interface LiveServerParams {
   remoteLogs?: boolean | Colors
   /** Set root directory that's being served. Defaults to cwd. */
   root?: string
+  /** Set root directory of the server. Useful if the server is behind a proxy. Defaults to empty string. */
+  serverRoot?: string
   /** This option lets the browser open with your local IP. */
   useLocalIp?: boolean
   /** Waits for all changes, before reloading. Defaults to 0ms. */


### PR DESCRIPTION
I specifically made these changes just so that I could use five-server-vscode with coder/code-server, and use the in-built port forwarding. (A reverse proxy which uses URL paths) 

The implementation may be the same as in VSCode for the Web, but I'm not entirely sure.

There will be a pull request for five-server-vscode also