### PR TITLE
update injectCode.ts to append code when closing tags not detected

### DIFF
--- a/src/middleware/injectCode.ts
+++ b/src/middleware/injectCode.ts
@@ -115,12 +115,9 @@ export const injectCode = (root: string, baseURL: string, PHP: any, injectBodyOp
       createReadStream(filePath)
         .pipe(inject)
         .on('finish', () => {
-          if (!inject.injectTag) return next()
-          else {
-            res.type('html')
-            res.setHeader('Content-Length', inject.data.length)
-            res.send(inject.data)
-          }
+          res.type('html')
+          res.setHeader('Content-Length', inject.data.length)
+          res.send(inject.data)
         })
         .on('error', () => {
           return next()

--- a/src/middleware/injectCode.ts
+++ b/src/middleware/injectCode.ts
@@ -48,6 +48,8 @@ export class Inject extends Writable {
 
     if (this.injectTag) {
       data = data.replace(this.injectTag, this.code + this.injectTag)
+    } else {
+      data = data + '\n' + this.code
     }
 
     // convert cache to [src|href]="/.cache/.."


### PR DESCRIPTION
Forces the injector to always inject the fiveserver client script, even if a head/html/body tag is not found.